### PR TITLE
Add document type response fields

### DIFF
--- a/veryfi/client_test.go
+++ b/veryfi/client_test.go
@@ -105,6 +105,10 @@ func setUp(t *testing.T, useDetailedReceipt bool) (test.HTTPServer, *Client, str
 				BoundingRegion: []float64{0.7646, 0.8789, 0.8823, 0.8789, 0.8823, 0.8906, 0.7646, 0.8906},
 				Rotation:       0,
 			},
+			DocumentType: &scheme.DetailedField{
+				Value: stringPtr("receipt"),
+				Score: float64Ptr(0.99),
+			},
 			DueDate: &scheme.DetailedDateField{
 				Value:          nil,
 				Score:          float64Ptr(1.0),
@@ -862,6 +866,7 @@ func setUp(t *testing.T, useDetailedReceipt bool) (test.HTTPServer, *Client, str
 			Created:       "2021-06-22 20:11:10",
 			CurrencyCode:  "USD",
 			Date:          "2021-06-22 16:11:10",
+			DocumentType:  "receipt",
 			ID:            36966934,
 			ImgFileName:   "7a0371f1-f695-4f9b-9e2b-da54cdf189fc.jpg",
 			InvoiceNumber: "98",

--- a/veryfi/scheme/document.go
+++ b/veryfi/scheme/document.go
@@ -181,6 +181,7 @@ type Document struct {
 	Discount                float64        `json:"discount"`
 	DocumentReferenceNumber string         `json:"document_reference_number"`
 	DocumentTitle           string         `json:"document_title"`
+	DocumentType            string         `json:"document_type"`
 	DuplicateOf             int            `json:"duplicate_of"`
 	DueDate                 string         `json:"due_date"`
 	ExchangeRate            float64        `json:"exch_rate"`
@@ -529,6 +530,7 @@ type DetailedDocument struct {
 	Date                *DetailedDateField  `json:"date"`
 	DeliveryDate        *DetailedDateField  `json:"delivery_date"`
 	Discount            *DetailedFloatField `json:"discount"`
+	DocumentType        *DetailedField      `json:"document_type"`
 	ReferenceNumber     *string             `json:"reference_number"`
 	DueDate             *DetailedDateField  `json:"due_date"`
 	ExternalID          *string             `json:"external_id"`

--- a/veryfi/testdata/receipt_public.json
+++ b/veryfi/testdata/receipt_public.json
@@ -12,6 +12,7 @@
     "currency_code": "USD",
     "date": "2021-06-22 16:11:10",
     "discount": 0.0,
+    "document_type": "receipt",
     "due_date": "",
     "external_id": "",
     "id": 36966934,


### PR DESCRIPTION
## Summary

- add `DocumentType` to `scheme.Document` for standard API responses
- add `DocumentType` to `scheme.DetailedDocument` with confidence metadata
- cover both response shapes in existing client tests
